### PR TITLE
added: headtracker_max_angle and headtracker_yaw_reset_shimmy

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -774,6 +774,7 @@ const clivalue_t valueTable[] = {
 #endif
 #ifdef USE_HEADTRACKER
     { "headtracker_max_angle",       VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 180}, PG_RX_CONFIG, offsetof(rxConfig_t, headtracker_max_angle) },
+    { "headtracker_yaw_reset_shimmy",VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_RX_CONFIG, offsetof(rxConfig_t, headtracker_yaw_reset_shimmy) },
 #endif
 #ifdef USE_SPEKTRUM_BIND
     { "spektrum_sat_bind",           VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { SPEKTRUM_SAT_BIND_DISABLED, SPEKTRUM_SAT_BIND_MAX}, PG_RX_CONFIG, offsetof(rxConfig_t, spektrum_sat_bind) },

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -772,6 +772,9 @@ const clivalue_t valueTable[] = {
 #ifdef USE_SERIALTX
     { "serialtx_inverted",           VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_RX_CONFIG, offsetof(rxConfig_t, serialtx_inverted) },
 #endif
+#ifdef USE_HEADTRACKER
+    { "headtracker_max_angle",       VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 180}, PG_RX_CONFIG, offsetof(rxConfig_t, headtracker_max_angle) },
+#endif
 #ifdef USE_SPEKTRUM_BIND
     { "spektrum_sat_bind",           VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { SPEKTRUM_SAT_BIND_DISABLED, SPEKTRUM_SAT_BIND_MAX}, PG_RX_CONFIG, offsetof(rxConfig_t, spektrum_sat_bind) },
     { "spektrum_sat_bind_autoreset", VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_RX_CONFIG, offsetof(rxConfig_t, spektrum_sat_bind_autoreset) },

--- a/src/main/io/headtracker.c
+++ b/src/main/io/headtracker.c
@@ -77,10 +77,12 @@ void taskHeadtracker(uint32_t currentTime)
         shimmyCount = 0;
     }
 
-    bool odd = shimmyCount % 2;
-    if ((odd && (yawGyro > SHIMMY_AMP)) || (!odd && (yawGyro < -SHIMMY_AMP))) {
-        shimmyStartTime = currentTime;
-        shimmyCount++;
+    if (rxConfig()->headtracker_yaw_reset_shimmy) {
+        bool odd = shimmyCount % 2;
+        if ((odd && (yawGyro > SHIMMY_AMP)) || (!odd && (yawGyro < -SHIMMY_AMP))) {
+            shimmyStartTime = currentTime;
+            shimmyCount++;
+        }
     }
 
     if ((headtrackerIO && !IORead(headtrackerIO)) || (shimmyCount == SHIMMY_COUNT)) {

--- a/src/main/io/headtracker.c
+++ b/src/main/io/headtracker.c
@@ -92,6 +92,15 @@ void taskHeadtracker(uint32_t currentTime)
     angles[PITCH] = attitude.values.pitch + 1800;
     angles[YAW] = (attitude.values.yaw + yawOffset) % 3600;
 
+    if (0 != rxConfig()->headtracker_max_angle) {
+        const int newValueMin = 1800 - rxConfig()->headtracker_max_angle * 10;
+        const int newValueMax = 1800 + rxConfig()->headtracker_max_angle * 10;
+        for (int channel = 0; channel < 3; channel++) {
+            angles[channel] = scaleRange(angles[channel], newValueMin, newValueMax, 0, 3600);
+            angles[channel] = constrain(angles[channel], 0, 3600);
+        }
+    }
+
     for (int channel = 0; channel < 3; channel++) {
         channels[channel] = angles[channel] * 2048 / 3600;
     }

--- a/src/main/pg/rx.c
+++ b/src/main/pg/rx.c
@@ -85,6 +85,7 @@ void pgResetFn_rxConfig(rxConfig_t *rxConfig)
         .serialrx_inverted = 0,
         .serialtx_inverted = 0,
         .headtracker_max_angle = 0,
+        .headtracker_yaw_reset_shimmy = 0,
         .spektrum_bind_pin_override_ioTag = IO_TAG(SPEKTRUM_BIND_PIN),
         .spektrum_bind_plug_ioTag = IO_TAG(BINDPLUG_PIN),
         .spektrum_sat_bind = 0,

--- a/src/main/pg/rx.c
+++ b/src/main/pg/rx.c
@@ -84,6 +84,7 @@ void pgResetFn_rxConfig(rxConfig_t *rxConfig)
         .serialrx_provider = SERIALRX_PROVIDER,
         .serialrx_inverted = 0,
         .serialtx_inverted = 0,
+        .headtracker_max_angle = 0,
         .spektrum_bind_pin_override_ioTag = IO_TAG(SPEKTRUM_BIND_PIN),
         .spektrum_bind_plug_ioTag = IO_TAG(BINDPLUG_PIN),
         .spektrum_sat_bind = 0,

--- a/src/main/pg/rx.h
+++ b/src/main/pg/rx.h
@@ -67,6 +67,7 @@ typedef struct rxConfig_s {
     uint8_t serialtx_inverted;                 // invert the serial TX protocol compared to it's default setting
     ioTag_t headtracker_ioTag;                 // Pin used to reset yaw on headtracker
     uint8_t headtracker_max_angle;             // angle for headtracker to report 100% as output; Leave at 0 to have 0 - 360 range
+    uint8_t headtracker_yaw_reset_shimmy;      // when true: resets yaw headtracker with head shimmy (quick small shaking)
 } rxConfig_t;
 
 PG_DECLARE(rxConfig_t, rxConfig);

--- a/src/main/pg/rx.h
+++ b/src/main/pg/rx.h
@@ -66,6 +66,7 @@ typedef struct rxConfig_s {
     uint8_t crsf_use_negotiated_baud;          // Use negotiated baud rate for CRSF V3
     uint8_t serialtx_inverted;                 // invert the serial TX protocol compared to it's default setting
     ioTag_t headtracker_ioTag;                 // Pin used to reset yaw on headtracker
+    uint8_t headtracker_max_angle;             // angle for headtracker to report 100% as output; Leave at 0 to have 0 - 360 range
 } rxConfig_t;
 
 PG_DECLARE(rxConfig_t, rxConfig);


### PR DESCRIPTION
Two commits:
1. when `headtracker_max_angle` is set > 0, for example 45, the headtracker will report  +/- 100% when angle is 45 degrees or more. Scales things in between -45 and 45.
2. if `headtracker_yaw_reset_shimmy` set to `OFF` or zero, then head shimmy won't reset yaw (useful for headtracker as motion controller)

To be improved further...
Maybe math could be more efficient and precise, but it works :)
